### PR TITLE
Update navbar links to open in new tab for specific items

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -19,14 +19,14 @@
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
               {%- for childlink in link[1] -%}
                 {%- for linkparts in childlink %}
-                  <a class="dropdown-item" href="{{ linkparts[1] | relative_url }}">{{ linkparts[0] }}</a>
+                  <a class="dropdown-item" href="{{ linkparts[1] | relative_url }}" target="_blank">{{ linkparts[0] }}</a>
                 {%- endfor -%}
-              {%- endfor %}
+              {%- endfor -%}
             </div>
           </li>
         {% else %}
           <li class="nav-item">
-            <a class="nav-link" href="{{ link[1] | relative_url }}">{{ link[0] }}</a>
+            <a class="nav-link" href="{{ link[1] | relative_url }}" {% if link[0] == "Join the Team" %}target="_blank"{% endif %}>{{ link[0] }}</a>
           </li>
         {%- endif -%}
       {%- endfor -%}
@@ -37,7 +37,7 @@
             <span id="nav-search-text">Search</span>
           </a>
         </li>
-      {%- endif -%}
+      {% endif %}
     </ul>
   </div>
 


### PR DESCRIPTION
### Description
This PR updates the navigation bar to ensure that certain links open in a new tab while others remain in the same tab.

- The **"About Us"** link will open in the **same** tab.
- Links under the **"Repositories"** dropdown will open in a **new** tab.
- The **"Join the Team"** link will open in a **new** tab.

### Changes Made
Modified **nav.html** to add target="_blank" attribute to the appropriate links.